### PR TITLE
Fix base config key

### DIFF
--- a/src/EEXFormatter.ts
+++ b/src/EEXFormatter.ts
@@ -97,7 +97,7 @@ export class EEXFormattingEditProvider implements vscode.DocumentFormattingEditP
     }
 
     private cli_options() {
-        const config = vscode.workspace.getConfiguration("vscode-erb-beautify")
+        const config = vscode.workspace.getConfiguration("vscode-yab-for-eex-leex")
         const acc: string[] = []
         return Object.keys(config).reduce(function (acc, key) {
             switch (key) {


### PR DESCRIPTION
Hey, just a small fix to get the correct keys configured by the extension (currently reading from the "vscode-erb-beautify" instead of "vscode-yab-for-eex-leex" base key).

Thank you!